### PR TITLE
Add Intercom PSA and Document Label PSA

### DIFF
--- a/Fun/Document Label PSA.txt
+++ b/Fun/Document Label PSA.txt
@@ -1,0 +1,26 @@
+# Document Label PSA
+█▀                           ▀█
+▌     [head=1]Document Label PSA[/head]         ▐
+█▄                           ▄█
+
+
+   [head=3]Ever seen a form with a header such as this?[/head]
+    ⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀
+   ▶ ⡇# Suit Sensors PSA ⠀         ⡇  ◀
+    ⡇[color=#5b97bc]█▄ █ ▀█▀[bold]Public Service Announcement[/bold][/color]⡇
+    ⡇[color=#5b97bc]█ ▀█     █   [bold]From the desk of Medical[/bold][/color]    ⡇
+    [color=gray]⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  ⠀⠀⠀ ⠀⠀⠀⠀⠀ ⡇
+    [/color][color=lightgray]⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  ⠀⠀ ⠀⠀⠀⠀⠀⠀ ⡇[/color]
+
+   [head=3]That's not a header! That's a document label![/head]
+
+    Fax machines allow you to print saved documents. When you print a document with one of these document labels, it will automatically label the paper with the provided text!
+
+    The label is [bold]not[/head] intended to be printed onto the page. PLEASE remove the label and the line it's on if you are not printing the document, but rather manually writing it.
+
+    If you are planning on properly using a document label, make sure it is formatted properly. It should always be the first line of your saved document.
+
+            [color=red]✘[/color]  [head=3]#label[/head] [color=red]✘[/color]
+
+           [color=green]✔[/color] [head=3]# label[/head] [color=green]✔[/color]
+          [italic]Don't forget the space![/head]

--- a/Fun/Intercom PSA.txt
+++ b/Fun/Intercom PSA.txt
@@ -1,0 +1,27 @@
+# No one at the desk? Intercom PSA
+[head=1]+―――――――[/head]
+[head=3] │ [/head][head=2]No one at the desk?[/head][head=3]
+ │ [/head][head=1]Use the Intercom![/head]
+[head=3] [color=#85877e]|[/head][/color]
+          Near this desk should be an intercom. See the figure
+      below for a visual reference. Using the intercom's
+      interface, select this department's channel. Enable both
+      the speaker and microphone, then simply ask for what
+      you need. After you're done speaking, please disable the
+      microphone.
+
+    ▄█▀▀██▀▀▀▀▀▀▀▀▀▀▀▀▄
+    █▒▒▒▒█▒▒[color=#00ffff]▄███▀█▄[/color]▒▒▒█
+    █▒▒▒▒█▒▒[color=#00ffff]▀█████▀[/color]▒▒▒█
+    ██▄▄██▄▄▄▄▄▄▄▄▄▄▄▄█
+    █▒[color=#86fa00]▄▄[/color]▒▒▒▄▄▒▄▄▒▒▒[color=#fa0000]▄▄[/color]▒█
+    ▀▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▀
+           [color=green]▲                [/color][color=darkred]▲[/color]
+            [color=green]│                        [/color][color=darkred]│[/color]
+            [color=green]│                        [/color][color=darkred]│[/color]
+            [color=green]│                           [/color][color=darkred]└─  [head=1]Speaker on[/head][/color]
+            [color=green]│             [/color][color=darkred][head=2]when lit[/head][/color]
+            [color=green]│
+            │
+            └─ [head=1]Microphone on[/head]
+         [head=2]when lit [/head] (turn off when done)[/color]


### PR DESCRIPTION
## About the PR
<!-- What did you change/add? -->
Added an Intercom PSA and a Document Label PSA to `/Fun`.
If you feel these forms should be placed in different directories, let me know.

## Why
<!-- Discuss the purpose of what you did/who will use it. -->
The Intercom PSA is designed for maps with intercoms. Department workers can leave this PSA at their front desk in order to inform people how to better get in contact with someone. Will hopefully help cut down on "Department to front!" spam in the commons radio channel.

The Document Label PSA is designed to easily inform people who are unaware of the document label in-game. It can be hard to explain the issue when it occurs, this aims to assist with that.

## Media
<!-- You must attach a screenshot of your entire document ingame. If the whole document does not fit in one screenshot, you must post multiple. -->
<!-- You are not required to post a screenshot if you only made a minor change to an existing document such as a spelling fix. -->
`# No one at the desk? Intercom PSA`
![Content Client_1zV5b8gvuu](https://github.com/user-attachments/assets/f932a999-25fa-4a2c-9a76-33c5c049858b)

`# Document Label PSA`
![Content Client_2g9xY3wYZx](https://github.com/user-attachments/assets/a39ab8ae-dd16-40c3-a562-0e2a94e522ca)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have followed [the guidelines](https://github.com/Moomoobeef/ss14-forms-txt/wiki/Guidelines).
- [X] I have included a screenshot, or this is a tiny edit.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
