### PR TITLE
"Jumpscare" images now use transparency.

### DIFF
--- a/Fun/Lizard Jumpscare.txt
+++ b/Fun/Lizard Jumpscare.txt
@@ -1,20 +1,20 @@
 # Lizard Jumpscare
-░░░░░░░░░░░░[color=#67CC40]████████████[/color]░░░░░░░░░░
-░░░░░░████[color=#6EC543]██[/color][color=#67CC40]████████[/color]██████░░░░░░░░
-░░░░████[color=#6EC543]██[/color][color=#67CC40]████████[/color]██████[color=#FFFFFF]██[/color]██░░░░░░
-░░░░██[color=#6EC543]██[/color][color=#67CC40]██████████[/color]██████████░░░░░░
-░░[color=#6EC543]██████[/color][color=#67CC40]██████████[/color]██████████░░░░░░
-[color=#6EC543]██████[/color][color=#67CC40]██████████████[/color]██████░░░░░░░░
-[color=#6EC543]██████[/color][color=#67CC40]████████████████████[/color]░░░░░░░░
-[color=#6EC543]██████████[/color][color=#67CC40]██████████████[/color]░░░░░░░░░░
-░░[color=#6EC543]██[/color][color=#FF2020]██[/color][color=#FF3D3D]██[/color][color=#6EC543]████████[/color][color=#67CC40]████[/color][color=#86E158]██[/color]░░░░░░░░░░░░
-░░░░[color=#FF2020]██[/color][color=#FF3D3D]██[/color]░░░░[color=#86E158]████████[/color][color=#6EC543]██[/color][color=#61D034]██[/color]░░░░░░░░[color=#56B037]██[/color]
-░░░░[color=#FF2020]██[/color]░░░░[color=#A8EB7A]██[/color][color=#B5EE85]██████[/color][color=#A8EB7A]██[/color][color=#6EC543]████[/color][color=#61D034]██[/color]░░░░[color=#56B037]██[/color][color=#48A926]██[/color]
-░░░░░░░░[color=#A8EB7A]██[/color][color=#B5EE85]██████████[/color][color=#A8EB7A]██[/color][color=#6EC543]████[/color][color=#56B037]██[/color][color=#48A926]██████[/color]
-░░░░[color=#6EC543]██[/color][color=#61D034]██[/color][color=#A8EB7A]██[/color][color=#B5EE85]██████████[/color][color=#A8EB7A]██[/color][color=#48A926]████████████[/color]
-░░░░[color=#6EC543]████[/color][color=#86E158]██[/color][color=#A8EB7A]██[/color][color=#B5EE85]████[/color][color=#A8EB7A]██[/color][color=#86E158]██[/color][color=#61D034]████[/color][color=#6EC543]██[/color][color=#48A926]████[/color][color=#52A037]██[/color]░░
-░░░░[color=#6EC543]████[/color][color=#61D034]██[/color][color=#86E158]████████[/color][color=#61D034]██[/color][color=#6EC543]██████[/color][color=#52A037]████[/color]░░░░
-░░░░░░[color=#6EC543]████[/color]░░░░░░░░[color=#6EC543]████████[/color]░░░░░░░░
-░░░░░░░░░░░░░░░░░░░░[color=#6EC543]████[/color]░░░░░░░░░░
+[color=#0000]░░░░░░░░░░░░[color=#67CC40]████████████[/color][/color]
+[color=#0000]░░░░░░[/color]████[color=#6EC543]██[/color][color=#67CC40]████████[/color]██████
+[color=#0000]░░░░[/color]████[color=#6EC543]██[/color][color=#67CC40]████████[/color]██████[color=#FFFFFF]██[/color]██
+[color=#0000]░░░░[/color]██[color=#6EC543]██[/color][color=#67CC40]██████████[/color]██████████
+[color=#0000]░░[/color][color=#6EC543]██████[/color][color=#67CC40]██████████[/color]██████████
+[color=#6EC543]██████[/color][color=#67CC40]██████████████[/color]██████
+[color=#6EC543]██████[/color][color=#67CC40]████████████████████[/color]
+[color=#6EC543]██████████[/color][color=#67CC40]██████████████[/color]
+[color=#0000]░░[/color][color=#6EC543]██[/color][color=#FF2020]██[/color][color=#FF3D3D]██[/color][color=#6EC543]████████[/color][color=#67CC40]████[/color][color=#86E158]██[/color]
+[color=#0000]░░░░[/color][color=#FF2020]██[/color][color=#FF3D3D]██[/color][color=#0000]░░░░[/color][color=#86E158]████████[/color][color=#6EC543]██[/color][color=#61D034]██[/color][color=#0000]░░░░░░░░[/color][color=#56B037]██[/color]
+[color=#0000]░░░░[/color][color=#FF2020]██[/color][color=#0000]░░░░[/color][color=#A8EB7A]██[/color][color=#B5EE85]██████[/color][color=#A8EB7A]██[/color][color=#6EC543]████[/color][color=#61D034]██[/color][color=#0000]░░░░[/color][color=#56B037]██[/color][color=#48A926]██[/color]
+[color=#0000]░░░░░░░░[/color][color=#A8EB7A]██[/color][color=#B5EE85]██████████[/color][color=#A8EB7A]██[/color][color=#6EC543]████[/color][color=#56B037]██[/color][color=#48A926]██████[/color]
+[color=#0000]░░░░[/color][color=#6EC543]██[/color][color=#61D034]██[/color][color=#A8EB7A]██[/color][color=#B5EE85]██████████[/color][color=#A8EB7A]██[/color][color=#48A926]████████████[/color]
+[color=#0000]░░░░[/color][color=#6EC543]████[/color][color=#86E158]██[/color][color=#A8EB7A]██[/color][color=#B5EE85]████[/color][color=#A8EB7A]██[/color][color=#86E158]██[/color][color=#61D034]████[/color][color=#6EC543]██[/color][color=#48A926]████[/color][color=#52A037]██[/color]
+[color=#0000]░░░░[/color][color=#6EC543]████[/color][color=#61D034]██[/color][color=#86E158]████████[/color][color=#61D034]██[/color][color=#6EC543]██████[/color][color=#52A037]████[/color]
+[color=#0000]░░░░░░[/color][color=#6EC543]████[/color][color=#0000]░░░░░░░░[/color][color=#6EC543]████████[/color]
+[color=#0000]░░░░░░░░░░░░░░░░░░░░[/color][color=#6EC543]████[/color]
 
 [color=#67CC40][head=1]                  WEH!![/head][/color]

--- a/Fun/Mothroach Jumpscare.txt
+++ b/Fun/Mothroach Jumpscare.txt
@@ -1,16 +1,16 @@
 # Mothroach Jumpscare
-░░░░░░░░░░░░░░░░░[color=#81572A]██[/color]░[color=#81572A]██[/color]░░░░░░░░░░░░░░░░
-░░░░░░░░░░░░░░░[color=#81572A]██[/color][color=#A1723C]█[/color][color=#81572A]███[/color][color=#A1723C]█[/color][color=#81572A]██[/color]░░░░░░░░░░░░░░
-░░░░░░░░░░░░░░[color=#81572A]█[/color][color=#A1723C]██[/color][color=#81572A]██[/color][color=#DBC18A]█[/color][color=#81572A]██[/color][color=#A1723C]██[/color][color=#81572A]█[/color]░░░░░░░░░░░░░
-░░░░░░░░░░░░[color=#E8CB8C]█[/color][color=#DFBF7B]███[/color][color=#E8CB8C]█[/color][color=#C7A565]█████[/color][color=#E8CB8C]█[/color][color=#DFBF7B]███[/color][color=#E8CB8C]█[/color]░░░░░░░░░░░
-░░░░░░░░░░░░[color=#81572A]█[/color][color=#F7D896]█[/color][color=#E8CB8C]██[/color][color=#DFBF7B]██[/color][color=#A1723C]███[/color][color=#DFBF7B]██[/color][color=#E8CB8C]██[/color][color=#F7D896]█[/color][color=#81572A]█[/color]░░░░░░░░░░░
-░░░░░░░░░░░░[color=#81572A]██[/color][color=#A1723C]█[/color][color=#C7A565]█[/color][color=#F7D896]█[/color][color=#A1723C]█[/color][color=#E5CD99]███[/color][color=#A1723C]█[/color][color=#F7D896]█[/color][color=#C7A565]█[/color][color=#A1723C]█[/color][color=#81572A]██[/color]░░░░░░░░░░░
-░░░░░░░░░░░░[color=#81572A]█[/color][color=#A1723C]█[/color][color=#DFBF7B]█[/color][color=#F7D896]█[/color][color=#A1723C]█[/color][color=#222021]█[/color][color=#DBC18A]█[/color][color=#E5CD99]█[/color][color=#DBC18A]█[/color][color=#222021]█[/color][color=#A1723C]█[/color][color=#F7D896]█[/color][color=#DFBF7B]█[/color][color=#A1723C]█[/color][color=#81572A]█[/color]░░░░░░░░░░░
-░░░░░░░░░░░░[color=#81572A]█[/color][color=#A1723C]█[/color][color=#DFBF7B]██[/color][color=#222021]█[/color][color=#2C2827]█[/color][color=#222021]█[/color][color=#DBC18A]█[/color][color=#222021]█[/color][color=#2C2827]█[/color][color=#222021]█[/color][color=#DFBF7B]██[/color][color=#A1723C]█[/color][color=#81572A]█[/color]░░░░░░░░░░░
-░░░░░░░░░░░░░[color=#81572A]█[/color][color=#C7A565]█[/color][color=#DFBF7B]█[/color][color=#A1723C]█[/color][color=#222021]█[/color][color=#DBC18A]███[/color][color=#222021]█[/color][color=#A1723C]█[/color][color=#DFBF7B]█[/color][color=#C7A565]█[/color][color=#81572A]█[/color]░░░░░░░░░░░░
-░░░░░░░░░░░░░░[color=#C7A565]█[/color][color=#E8CB8C]█[/color][color=#DFBF7B]█[/color][color=#A1723C]█[/color][color=#D4AF6B]███[/color][color=#A1723C]█[/color][color=#DFBF7B]█[/color][color=#E8CB8C]█[/color][color=#C7A565]█[/color]░░░░░░░░░░░░░
-░░░░░░░░░░░░░░░[color=#C7A565]█[/color][color=#DFBF7B]█[/color][color=#F7D896]█[/color][color=#A1723C]███[/color][color=#F7D896]█[/color][color=#DFBF7B]█[/color][color=#C7A565]█[/color]░░░░░░░░░░░░░░
-░░░░░░░░░░░░░░░[color=#A1723C]█[/color][color=#E8CB8C]█[/color][color=#F7D896]█[/color][color=#DFBF7B]███[/color][color=#F7D896]█[/color][color=#E8CB8C]█[/color][color=#A1723C]█[/color]░░░░░░░░░░░░░░
-░░░░░░░░░░░░░░░[color=#2E2A26]█[/color][color=#222021]█[/color][color=#C7A565]█████[/color][color=#222021]█[/color][color=#2E2A26]█[/color]░░░░░░░░░░░░░░
+[color=#0000]████████████████[color=#81572A]████[color=#0000]██[color=#81572A]████
+[color=#0000]████████████[color=#81572A]████[color=#A1723C]██[color=#81572A]██████[color=#A1723C]██[color=#81572A]████
+[color=#0000]██████████[color=#81572A]██[color=#A1723C]████[color=#81572A]████[color=#DBC18A]██[color=#81572A]████[color=#A1723C]████[color=#81572A]██
+[color=#0000]██████[color=#E8CB8C]██[color=#DFBF7B]██████[color=#E8CB8C]██[color=#C7A565]██████████[color=#E8CB8C]██[color=#DFBF7B]██████[color=#E8CB8C]██
+[color=#0000]██████[color=#81572A]██[color=#F7D896]██[color=#E8CB8C]████[color=#DFBF7B]████[color=#A1723C]██████[color=#DFBF7B]████[color=#E8CB8C]████[color=#F7D896]██[color=#81572A]██
+[color=#0000]██████[color=#81572A]████[color=#A1723C]██[color=#C7A565]██[color=#F7D896]██[color=#A1723C]██[color=#E5CD99]██████[color=#A1723C]██[color=#F7D896]██[color=#C7A565]██[color=#A1723C]██[color=#81572A]████
+[color=#0000]██████[color=#81572A]██[color=#A1723C]██[color=#DFBF7B]██[color=#F7D896]██[color=#A1723C]██[color=#222021]██[color=#DBC18A]██[color=#E5CD99]██[color=#DBC18A]██[color=#222021]██[color=#A1723C]██[color=#F7D896]██[color=#DFBF7B]██[color=#A1723C]██[color=#81572A]██
+[color=#0000]██████[color=#81572A]██[color=#A1723C]██[color=#DFBF7B]████[color=#222021]██[color=#2C2827]██[color=#222021]██[color=#DBC18A]██[color=#222021]██[color=#2C2827]██[color=#222021]██[color=#DFBF7B]████[color=#A1723C]██[color=#81572A]██
+[color=#0000]████████[color=#81572A]██[color=#C7A565]██[color=#DFBF7B]██[color=#A1723C]██[color=#222021]██[color=#DBC18A]██████[color=#222021]██[color=#A1723C]██[color=#DFBF7B]██[color=#C7A565]██[color=#81572A]██
+[color=#0000]██████████[color=#C7A565]██[color=#E8CB8C]██[color=#DFBF7B]██[color=#A1723C]██[color=#D4AF6B]██████[color=#A1723C]██[color=#DFBF7B]██[color=#E8CB8C]██[color=#C7A565]██
+[color=#0000]████████████[color=#C7A565]██[color=#DFBF7B]██[color=#F7D896]██[color=#A1723C]██████[color=#F7D896]██[color=#DFBF7B]██[color=#C7A565]██
+[color=#0000]████████████[color=#A1723C]██[color=#E8CB8C]██[color=#F7D896]██[color=#DFBF7B]██████[color=#F7D896]██[color=#E8CB8C]██[color=#A1723C]██
+[color=#0000]████████████[color=#2E2A26]██[color=#222021]██[color=#C7A565]██████████[color=#222021]██[color=#2E2A26]██
 
-[color=#A1723C][head=1]                  *chitters*[/head][/color]
+[color=#A1723C] [head=1]                  *chitters*[/head][color=#000]


### PR DESCRIPTION
## About the PR
**Little known fact:** the color tag supports alpha channel (such as #00000000)
It also supports shorthand (such as #123, which would be equivalent to #112233)
and it supports both simultaneously (such as #0000)

## Why
<!-- Discuss the purpose of what you did/who will use it. -->

## Media
<img width="897" height="453" alt="image" src="https://github.com/user-attachments/assets/405c4c29-af1c-4fc4-9800-9cbf69fc61c2" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have followed [the guidelines](https://github.com/Moomoobeef/ss14-forms-txt/wiki/Guidelines).
- [X] I have included a screenshot, or this is a tiny edit.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
